### PR TITLE
fix: update ECR image references and add branch debugging

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -35,6 +35,18 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.branch || 'develop' }}
+    
+    - name: Debug branch information
+      run: |
+        echo "🔍 Branch Debug Information:"
+        echo "  - Input branch: ${{ github.event.inputs.branch }}"
+        echo "  - Default branch: develop"
+        echo "  - Selected branch: ${{ github.event.inputs.branch || 'develop' }}"
+        echo "  - Current HEAD: $(git rev-parse HEAD)"
+        echo "  - Current branch: $(git branch --show-current)"
+        echo "  - All branches: $(git branch -a)"
+        echo "  - Recent commits:"
+        git log --oneline -5
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -66,11 +78,11 @@ jobs:
         
         # ECR Repository URLs
         ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
-        ECR_EUREKA_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/shoplite-eureka:latest
+        ECR_EUREKA_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/shoplite-eureka-server:latest
         ECR_API_GATEWAY_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/shoplite-api-gateway:latest
-        ECR_ORDER_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/shoplite-order:latest
-        ECR_CATALOG_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/shoplite-catalog:latest
-        ECR_AUTH_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/shoplite-auth:latest
+        ECR_ORDER_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/shoplite-order-service:latest
+        ECR_CATALOG_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/shoplite-catalog-service:latest
+        ECR_AUTH_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/shoplite-auth-service:latest
         ECR_FRONTEND_IMAGE=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/shoplite-frontend:latest
         
         # Service Discovery


### PR DESCRIPTION
- Fix ECR image names to include -server suffix for eureka, order, catalog, auth services
- Add debug step to show branch information during workflow execution
- This will help troubleshoot why 'main' appears instead of 'develop'
- ECR references now match actual repository names